### PR TITLE
No eTag fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1413,7 +1413,8 @@ function compareMultipartETag(eTag, multipartETag) {
 }
 
 function getETagCount(eTag) {
-  var match = (eTag || "").match(/[a-fA-F0-9]{32}-(\d+)$/);
+  if (!eTag) return 0;
+  var match = eTag.match(/[a-fA-F0-9]{32}-(\d+)$/);
   return match ? parseInt(match[1], 10) : 1;
 }
 


### PR DESCRIPTION
Some S3 servers do not send eTag header at all. In this case we shoudn't raise "ETag does not match MD5 checksum" error.